### PR TITLE
Arregla representación de matriz A en cml

### DIFF
--- a/7-cml.tex
+++ b/7-cml.tex
@@ -47,10 +47,10 @@ realicen el mínimo
     + \dots + a_n \cdot \varphi_n(x_i) - y_i \big)^2 \]
 o, considerando,
 \[ \mat{A} = \begin{bmatrix}
-    \varphi_1(x_1) & \varphi_1(x_2) & \cdots & \varphi_1(x_m) \\
-    \varphi_2(x_1) & \varphi_2(x_2) & \cdots & \varphi_2(x_m) \\
+    \varphi_1(x_1) & \varphi_2(x_1) & \cdots & \varphi_n(x_1) \\
+    \varphi_1(x_2) & \varphi_2(x_2) & \cdots & \varphi_n(x_2) \\
     \vdots         & \vdots         & \ddots & \vdots \\
-    \varphi_n(x_1) & \varphi_n(x_2) & \cdots & \varphi_n(x_m) 
+    \varphi_1(x_m) & \varphi_2(x_m) & \cdots & \varphi_n(x_m) 
 \end{bmatrix} \qquad
 \vec{x} = \begin{bmatrix}
     a_1 \\ a_2 \\ \vdots \\ a_n


### PR DESCRIPTION
Estaba como si tuviera ancho m y alto n, y en realidad es al revés.